### PR TITLE
fix: GlobalExceptionHandler에 @Hidden 애노테이션 추가

### DIFF
--- a/src/main/java/com/example/task/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/task/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.task.global.error;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.server.ResponseStatusException;
 
+@Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 


### PR DESCRIPTION
- Spring Boot 3.4.0 이상의 버전은 Swagger와 충돌 현상 생김
- @Hidden 사용해 해결
- 참고: https://velog.io/@sinryuji/Swagger%EC%99%80-RestControllerAdvice-%EC%B6%A9%EB%8F%8C-%EB%AC%B8%EC%A0%9C